### PR TITLE
[FE] useFetch 상태 분리

### DIFF
--- a/fe/src/components/ProductList/index.tsx
+++ b/fe/src/components/ProductList/index.tsx
@@ -8,7 +8,7 @@ import { RESPONSE_STATE, REQUEST_METHOD } from '@constants/index';
 import ProductListItem, { ProductListItemProps } from '@components/ProductListItem';
 import * as S from './style';
 
-interface Data {
+interface PostsData {
   posts: { content: ProductListItemProps[]; last: boolean };
 }
 
@@ -16,7 +16,7 @@ const ProductList = () => {
   const [pageNum, setPageNum] = useState(0);
   const [postList, setPostList] = useState<ProductListItemProps[]>([]);
 
-  const { fetchData, responseState, data } = useFetch<Data>({
+  const { fetchData, responseState, data } = useFetch<PostsData>({
     url: `http://13.124.150.120:8080/posts?page=${pageNum}&size=10`,
     method: REQUEST_METHOD.GET,
   });

--- a/fe/src/components/ProductList/index.tsx
+++ b/fe/src/components/ProductList/index.tsx
@@ -3,10 +3,12 @@ import { useState, useEffect } from 'react';
 import useFetch from '@hooks/useFetch';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 
+import { RESPONSE_STATE, REQUEST_METHOD } from '@constants/index';
+
 import ProductListItem, { ProductListItemProps } from '@components/ProductListItem';
 import * as S from './style';
 
-interface PostsApiResponse {
+interface Data {
   posts: { content: ProductListItemProps[]; last: boolean };
 }
 
@@ -14,15 +16,15 @@ const ProductList = () => {
   const [pageNum, setPageNum] = useState(0);
   const [postList, setPostList] = useState<ProductListItemProps[]>([]);
 
-  const { fetchData, fetchState } = useFetch<PostsApiResponse>({
+  const { fetchData, responseState, data } = useFetch<Data>({
     url: `http://13.124.150.120:8080/posts?page=${pageNum}&size=10`,
-    method: 'GET',
+    method: REQUEST_METHOD.GET,
   });
 
   const intersectHandler: IntersectionObserverCallback = ([entry]) => {
     if (!entry.isIntersecting) return;
 
-    if (fetchState.state === 'SUCCESS' && !fetchState.data?.posts.last) {
+    if (responseState === RESPONSE_STATE.SUCCESS && !data?.posts.last) {
       setPageNum((previousPageNum) => previousPageNum + 1);
     }
   };
@@ -34,24 +36,23 @@ const ProductList = () => {
   }, [pageNum]);
 
   useEffect(() => {
-    if (fetchState.state !== 'SUCCESS' || !fetchState.data) return;
+    if (responseState !== RESPONSE_STATE.SUCCESS || !data) return;
 
-    const { posts } = fetchState.data;
-    setPostList((previous) => [...previous, ...posts.content]);
-  }, [fetchState.state, fetchState.data]);
+    setPostList((previous) => [...previous, ...data.posts.content]);
+  }, [responseState, data]);
 
   return (
     <S.ProductList>
-      {fetchState.state === 'SUCCESS' && fetchState.data && (
+      {responseState === RESPONSE_STATE.SUCCESS && data && (
         <>
           {postList.map((item) => (
             <ProductListItem key={item.id} {...item} />
           ))}
-          {!fetchState.data.posts.last && <S.Target ref={setTarget}></S.Target>}
+          {!data.posts.last && <S.Target ref={setTarget}></S.Target>}
         </>
       )}
 
-      {fetchState.state === 'LOADING' && (
+      {responseState === RESPONSE_STATE.LOADING && (
         <>
           {postList.length > 0 ? (
             <>
@@ -66,7 +67,7 @@ const ProductList = () => {
         </>
       )}
 
-      {fetchState.state === 'ERROR' && <h1>Error</h1>}
+      {responseState === RESPONSE_STATE.ERROR && <h1>Error</h1>}
     </S.ProductList>
   );
 };

--- a/fe/src/constants/index.ts
+++ b/fe/src/constants/index.ts
@@ -17,4 +17,19 @@ const ICON_NAME = {
   SEARCH: 'search',
 } as const;
 
-export { ICON_NAME };
+const RESPONSE_STATE = {
+  IDLE: 'IDLE',
+  LOADING: 'LOADING',
+  ERROR: 'ERROR',
+  SUCCESS: 'SUCCESS',
+} as const;
+
+const REQUEST_METHOD = {
+  GET: 'GET',
+  POST: 'POST',
+  PUT: 'PUT',
+  DELETE: 'DELETE',
+  PATCH: 'PATCH',
+} as const;
+
+export { ICON_NAME, RESPONSE_STATE, REQUEST_METHOD };

--- a/fe/src/hooks/useFetch.ts
+++ b/fe/src/hooks/useFetch.ts
@@ -5,7 +5,6 @@ import { RESPONSE_STATE, REQUEST_METHOD } from '@constants/index';
 type ResponseState = (typeof RESPONSE_STATE)[keyof typeof RESPONSE_STATE];
 type DataState<T> = null | T;
 type ErrorState = null | Error;
-
 type Method = (typeof REQUEST_METHOD)[keyof typeof REQUEST_METHOD];
 
 interface UseFetchProps {
@@ -33,7 +32,11 @@ const useFetch = <T>({ url, method = REQUEST_METHOD.GET, body = null }: UseFetch
         options.headers = { Authorization: `Bearer ${token}` };
       }
 
-      if (['POST', 'PUT', 'PATCH'].includes(method)) {
+      if (
+        method === REQUEST_METHOD.PATCH ||
+        method === REQUEST_METHOD.POST ||
+        method === REQUEST_METHOD.PUT
+      ) {
         if (!options.body) {
           throw new Error(`Request failed for ${method} ${url}. Please provide a valid request body.`);
         }

--- a/fe/src/hooks/useFetch.ts
+++ b/fe/src/hooks/useFetch.ts
@@ -5,6 +5,7 @@ import { RESPONSE_STATE, REQUEST_METHOD } from '@constants/index';
 type ResponseState = (typeof RESPONSE_STATE)[keyof typeof RESPONSE_STATE];
 type DataState<T> = null | T;
 type ErrorState = null | Error;
+
 type Method = (typeof REQUEST_METHOD)[keyof typeof REQUEST_METHOD];
 
 interface UseFetchProps {
@@ -32,11 +33,11 @@ const useFetch = <T>({ url, method = REQUEST_METHOD.GET, body = null }: UseFetch
         options.headers = { Authorization: `Bearer ${token}` };
       }
 
-      if (['POST', 'PUT', 'PATCH'].includes(method) && !options.body) {
-        throw new Error('body가 없습니다');
-      }
+      if (['POST', 'PUT', 'PATCH'].includes(method)) {
+        if (!options.body) {
+          throw new Error(`Request failed for ${method} ${url}. Please provide a valid request body.`);
+        }
 
-      if (body) {
         options.body = JSON.stringify(body);
         options.headers = { 'Content-Type': 'application/json' };
       }
@@ -44,7 +45,7 @@ const useFetch = <T>({ url, method = REQUEST_METHOD.GET, body = null }: UseFetch
       const response = await fetch(url, options);
 
       if (!response.ok) {
-        throw new Error(`${response.status}`);
+        throw new Error(`Request failed for ${method} ${url}. Status: ${response.status}.`);
       }
 
       const result = await response.json();

--- a/fe/src/hooks/useFetch.ts
+++ b/fe/src/hooks/useFetch.ts
@@ -1,24 +1,27 @@
 import { useState, useEffect } from 'react';
 
-interface UseFetchState<T> {
-  state: 'IDLE' | 'LOADING' | 'ERROR' | 'SUCCESS';
-  data: null | T;
-  error: null | Error;
-}
+import { RESPONSE_STATE, REQUEST_METHOD } from '@constants/index';
+
+type ResponseState = (typeof RESPONSE_STATE)[keyof typeof RESPONSE_STATE];
+type DataState<T> = null | T;
+type ErrorState = null | Error;
+type Method = (typeof REQUEST_METHOD)[keyof typeof REQUEST_METHOD];
 
 interface UseFetchProps {
   url: string;
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  method?: Method;
   body?: object | null;
 }
 
-const useFetch = <T>({ url, method = 'GET', body = null }: UseFetchProps) => {
-  const [fetchState, setFetchState] = useState<UseFetchState<T>>({ state: 'IDLE', data: null, error: null });
+const useFetch = <T>({ url, method = REQUEST_METHOD.GET, body = null }: UseFetchProps) => {
+  const [responseState, setResponseState] = useState<ResponseState>(RESPONSE_STATE.IDLE);
+  const [data, setData] = useState<DataState<T>>(null);
+  const [error, setError] = useState<ErrorState>(null);
   const token = localStorage.getItem('Token');
 
   const fetchData = async () => {
     try {
-      setFetchState((previous) => ({ ...previous, state: 'LOADING' }));
+      setResponseState(RESPONSE_STATE.LOADING);
 
       const options: RequestInit = {
         method,
@@ -30,7 +33,7 @@ const useFetch = <T>({ url, method = 'GET', body = null }: UseFetchProps) => {
       }
 
       if (['POST', 'PUT', 'PATCH'].includes(method) && !options.body) {
-        throw new Error('body가 없습니다')
+        throw new Error('body가 없습니다');
       }
 
       if (body) {
@@ -48,13 +51,19 @@ const useFetch = <T>({ url, method = 'GET', body = null }: UseFetchProps) => {
 
       // todo: 백엔드와 데이터 형식 협의
       if (result.token) {
-        setFetchState({ state: 'SUCCESS', data: result.token, error: null });
+        setResponseState(RESPONSE_STATE.SUCCESS);
+        setData(result.token);
+        setError(null);
         return;
       }
 
-      setFetchState({ state: 'SUCCESS', data: result.data, error: null });
+      setResponseState(RESPONSE_STATE.SUCCESS);
+      setData(result.data);
+      setError(null);
     } catch (err) {
-      setFetchState({ state: 'ERROR', data: null, error: err as Error });
+      setResponseState(RESPONSE_STATE.ERROR);
+      setData(null);
+      setError(err as Error);
     }
   };
 
@@ -62,7 +71,7 @@ const useFetch = <T>({ url, method = 'GET', body = null }: UseFetchProps) => {
     fetchData();
   }, []);
 
-  return { fetchData, fetchState };
+  return { fetchData, responseState, data, error };
 };
 
 export default useFetch;

--- a/fe/src/pages/LoginLoading/index.tsx
+++ b/fe/src/pages/LoginLoading/index.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { REQUEST_METHOD } from '@constants/index';
+
 import useFetch from '@hooks/useFetch';
+
+// TODO: BE와 데이터 구조 협의
+type Data = string;
 
 const LoginLoading = () => {
   const navigate = useNavigate();
@@ -9,19 +14,17 @@ const LoginLoading = () => {
   const urlParams = new URLSearchParams(queryString);
   const codeParam = urlParams.get('code');
 
-  const { fetchState } = useFetch<string>({
+  const { data: token } = useFetch<Data>({
     url: `http://13.124.150.120:8080/oauth?code=${codeParam}`,
-    method: 'GET',
+    method: REQUEST_METHOD.GET,
   });
 
   useEffect(() => {
-    const { data: token } = fetchState;
-
     if (token && !localStorage.getItem('Token')) {
       localStorage.setItem('Token', token);
       navigate('/');
     }
-  }, [fetchState.data]);
+  }, [token]);
 
   return <div>loading</div>;
 };

--- a/fe/src/pages/LoginLoading/index.tsx
+++ b/fe/src/pages/LoginLoading/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { REQUEST_METHOD } from '@constants/index';
+import { REQUEST_METHOD, RESPONSE_STATE } from '@constants/index';
 
 import useFetch from '@hooks/useFetch';
 
@@ -14,17 +14,24 @@ const LoginLoading = () => {
   const urlParams = new URLSearchParams(queryString);
   const codeParam = urlParams.get('code');
 
-  const { data: token } = useFetch<Data>({
+  const { responseState, data: token } = useFetch<Data>({
     url: `http://13.124.150.120:8080/oauth?code=${codeParam}`,
     method: REQUEST_METHOD.GET,
   });
 
   useEffect(() => {
-    if (token && !localStorage.getItem('Token')) {
+    const isLoggedIn = localStorage.getItem('Token');
+
+    if (isLoggedIn) navigate('/');
+
+    if (responseState !== RESPONSE_STATE.SUCCESS) return;
+
+    if (token) {
       localStorage.setItem('Token', token);
-      navigate('/');
     }
-  }, [token]);
+
+    navigate('/');
+  }, [responseState, token]);
 
   return <div>loading</div>;
 };


### PR DESCRIPTION
- #101 

## ✅ 진행한 작업
- fetchState를 data, error, responseState로 분리
- useFetch의 반환값 변경 (반환값: `{ fetchData, data, error, responseState }`)
- useFetch 선언하는 컴포넌트 수정 (ProductList, LoginLoading)

해당 로직은 [노션](https://www.notion.so/login-useFetch-90e8addd961d4e67b24623d45cc59b69)에 정리해두었습니다.