### PR TITLE
[FE] 카테고리 페이지의 카테고리 버튼 

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@context/themeContext';
 import Home from '@pages/Home';
 import RegionSetting from '@pages/RegionSetting';
 import Category from '@pages/Category';
+import CategoryDetail from '@pages/CategoryDetail';
 import Sales from '@pages/Sales';
 import Interests from '@pages/Interests';
 import Chatting from '@pages/Chatting';
@@ -15,7 +16,6 @@ import NewProduct from '@pages/NewProduct';
 import NotFound from '@pages/NotFound';
 
 import GlobalStyle from '@styles/GlobalStyle';
-import CategoryDetail from '@pages/CategoryDetail';
 
 const App = () => {
   return (

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -15,6 +15,7 @@ import NewProduct from '@pages/NewProduct';
 import NotFound from '@pages/NotFound';
 
 import GlobalStyle from '@styles/GlobalStyle';
+import CategoryDetail from '@pages/CategoryDetail';
 
 const App = () => {
   return (
@@ -25,6 +26,7 @@ const App = () => {
           <Route index path="/" element={<Home />} />
           <Route path="/region-setting" element={<RegionSetting />} />
           <Route path="/categories" element={<Category />} />
+          <Route path="/categories/detail" element={<CategoryDetail />} />
           <Route path="/sales" element={<Sales />} />
           <Route path="/interests" element={<Interests />} />
           <Route path="/chatting" element={<Chatting />} />

--- a/fe/src/components/ProductList/index.tsx
+++ b/fe/src/components/ProductList/index.tsx
@@ -12,12 +12,18 @@ interface PostsData {
   posts: { content: ProductListItemProps[]; last: boolean };
 }
 
-const ProductList = () => {
+interface ProductListProps {
+  categoryId?: number;
+}
+
+const ProductList = ({ categoryId }: ProductListProps) => {
   const [pageNum, setPageNum] = useState(0);
   const [postList, setPostList] = useState<ProductListItemProps[]>([]);
 
   const { fetchData, responseState, data } = useFetch<PostsData>({
-    url: `http://13.124.150.120:8080/posts?page=${pageNum}&size=10`,
+    url: `http://13.124.150.120:8080/posts?page=${pageNum}&size=10${
+      categoryId ? `&category=${categoryId}` : ''
+    }`,
     method: REQUEST_METHOD.GET,
   });
 

--- a/fe/src/components/ProductList/index.tsx
+++ b/fe/src/components/ProductList/index.tsx
@@ -51,9 +51,12 @@ const ProductList = ({ categoryId }: ProductListProps) => {
     <S.ProductList>
       {responseState === RESPONSE_STATE.SUCCESS && data && (
         <>
-          {postList.map((item) => (
-            <ProductListItem key={item.id} {...item} />
-          ))}
+          {postList.length > 0 ? (
+            postList.map((item) => <ProductListItem key={item.id} {...item} />)
+          ) : (
+            <S.ProductNotFound>해당 상품이 없어요.</S.ProductNotFound>
+          )}
+
           {!data.posts.last && <S.Target ref={setTarget}></S.Target>}
         </>
       )}

--- a/fe/src/components/ProductList/style.ts
+++ b/fe/src/components/ProductList/style.ts
@@ -9,4 +9,15 @@ const Target = styled.div`
   height: 1px;
 `;
 
-export { ProductList, Target };
+const ProductNotFound = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: ${({ theme }) => theme.fonts.callout.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.callout.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.callout.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.strong};
+`;
+
+export { ProductList, Target, ProductNotFound };

--- a/fe/src/pages/Category/index.tsx
+++ b/fe/src/pages/Category/index.tsx
@@ -38,13 +38,16 @@ const Category = () => {
 
       {responseState === RESPONSE_STATE.LOADING && <div>loading</div>}
       {responseState === RESPONSE_STATE.ERROR && <div>error</div>}
-      {responseState === RESPONSE_STATE.SUCCESS &&
-        data?.categories.map((item) => (
-          <S.CategoryItem key={item.id}>
-            <S.CategoryImg src={item.photoUrl} />
-            <span>{item.name}</span>
-          </S.CategoryItem>
-        ))}
+      {responseState === RESPONSE_STATE.SUCCESS && (
+        <S.CategoryList>
+          {data?.categories.map((item) => (
+            <S.CategoryItem key={item.id}>
+              <S.CategoryImg src={item.photoUrl} />
+              <span>{item.name}</span>
+            </S.CategoryItem>
+          ))}
+        </S.CategoryList>
+      )}
     </>
   );
 };

--- a/fe/src/pages/Category/index.tsx
+++ b/fe/src/pages/Category/index.tsx
@@ -1,12 +1,10 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { ICON_NAME, REQUEST_METHOD, RESPONSE_STATE } from '@constants/index';
 
 import useFetch from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
-import ProductList from '@components/ProductList';
 import * as S from './style';
 
 interface Category {
@@ -19,31 +17,13 @@ interface CategoriesData {
   categories: Category[];
 }
 
-type ClickedCategoryState<T> = null | T;
-
 const Category = () => {
-  const [clickedCategory, setClickedCategory] =
-    useState<ClickedCategoryState<{ id: number; name: string }>>(null);
+  const navigate = useNavigate();
 
   const { responseState, data } = useFetch<CategoriesData>({
     url: 'http://13.124.150.120:8080/categories',
     method: REQUEST_METHOD.GET,
   });
-
-  if (clickedCategory) {
-    return (
-      <>
-        <S.Header>
-          <S.BackButton onClick={() => setClickedCategory(null)}>
-            <Icon name={ICON_NAME.CHEVRON_LEFT} />
-          </S.BackButton>
-          <S.HeaderTitle>{clickedCategory.name}</S.HeaderTitle>
-          <S.EmptyTag></S.EmptyTag>
-        </S.Header>
-        <ProductList categoryId={clickedCategory.id} />
-      </>
-    );
-  }
 
   return (
     <>
@@ -63,7 +43,7 @@ const Category = () => {
       {responseState === RESPONSE_STATE.SUCCESS && (
         <S.CategoryList>
           {data?.categories.map(({ id, name, photoUrl }) => (
-            <S.CategoryItem key={id} onClick={() => setClickedCategory({ id, name })}>
+            <S.CategoryItem key={id} onClick={() => navigate(`/categories/detail?id=${id}&name=${name}`)}>
               <S.CategoryImg src={photoUrl} alt={name} />
               <span>{name}</span>
             </S.CategoryItem>

--- a/fe/src/pages/Category/index.tsx
+++ b/fe/src/pages/Category/index.tsx
@@ -6,6 +6,7 @@ import { ICON_NAME, REQUEST_METHOD, RESPONSE_STATE } from '@constants/index';
 import useFetch from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
+import ProductList from '@components/ProductList';
 import * as S from './style';
 
 interface Category {
@@ -23,10 +24,26 @@ type ClickedCategoryState<T> = null | T;
 const Category = () => {
   const [clickedCategory, setClickedCategory] =
     useState<ClickedCategoryState<{ id: number; name: string }>>(null);
+
   const { responseState, data } = useFetch<CategoriesData>({
     url: 'http://13.124.150.120:8080/categories',
     method: REQUEST_METHOD.GET,
   });
+
+  if (clickedCategory) {
+    return (
+      <>
+        <S.Header>
+          <S.BackButton onClick={() => setClickedCategory(null)}>
+            <Icon name={ICON_NAME.CHEVRON_LEFT} />
+          </S.BackButton>
+          <S.HeaderTitle>{clickedCategory.name}</S.HeaderTitle>
+          <S.EmptyTag></S.EmptyTag>
+        </S.Header>
+        <ProductList categoryId={clickedCategory.id} />
+      </>
+    );
+  }
 
   return (
     <>

--- a/fe/src/pages/Category/index.tsx
+++ b/fe/src/pages/Category/index.tsx
@@ -39,7 +39,12 @@ const Category = () => {
       {responseState === RESPONSE_STATE.LOADING && <div>loading</div>}
       {responseState === RESPONSE_STATE.ERROR && <div>error</div>}
       {responseState === RESPONSE_STATE.SUCCESS &&
-        data?.categories.map((item) => <div key={item.id}>{item.name}</div>)}
+        data?.categories.map((item) => (
+          <S.CategoryItem key={item.id}>
+            <S.CategoryImg src={item.photoUrl} />
+            <span>{item.name}</span>
+          </S.CategoryItem>
+        ))}
     </>
   );
 };

--- a/fe/src/pages/Category/index.tsx
+++ b/fe/src/pages/Category/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { ICON_NAME, REQUEST_METHOD, RESPONSE_STATE } from '@constants/index';
@@ -17,7 +18,11 @@ interface CategoriesData {
   categories: Category[];
 }
 
+type ClickedCategoryState<T> = null | T;
+
 const Category = () => {
+  const [clickedCategory, setClickedCategory] =
+    useState<ClickedCategoryState<{ id: number; name: string }>>(null);
   const { responseState, data } = useFetch<CategoriesData>({
     url: 'http://13.124.150.120:8080/categories',
     method: REQUEST_METHOD.GET,
@@ -40,10 +45,10 @@ const Category = () => {
       {responseState === RESPONSE_STATE.ERROR && <div>error</div>}
       {responseState === RESPONSE_STATE.SUCCESS && (
         <S.CategoryList>
-          {data?.categories.map((item) => (
-            <S.CategoryItem key={item.id}>
-              <S.CategoryImg src={item.photoUrl} />
-              <span>{item.name}</span>
+          {data?.categories.map(({ id, name, photoUrl }) => (
+            <S.CategoryItem key={id} onClick={() => setClickedCategory({ id, name })}>
+              <S.CategoryImg src={photoUrl} alt={name} />
+              <span>{name}</span>
             </S.CategoryItem>
           ))}
         </S.CategoryList>

--- a/fe/src/pages/Category/index.tsx
+++ b/fe/src/pages/Category/index.tsx
@@ -1,21 +1,46 @@
-import { ICON_NAME } from '@constants/index';
+import { Link } from 'react-router-dom';
+
+import { ICON_NAME, REQUEST_METHOD, RESPONSE_STATE } from '@constants/index';
+
+import useFetch from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
 import * as S from './style';
-import { Link } from 'react-router-dom';
+
+interface Category {
+  id: number;
+  name: string;
+  photoUrl: string;
+}
+
+interface CategoriesData {
+  categories: Category[];
+}
 
 const Category = () => {
+  const { responseState, data } = useFetch<CategoriesData>({
+    url: 'http://13.124.150.120:8080/categories',
+    method: REQUEST_METHOD.GET,
+  });
+
   return (
-    <S.Header>
-      <Link to="/">
-        <S.BackButton>
-          <Icon name={ICON_NAME.CHEVRON_LEFT} />
-          <span>뒤로</span>
-        </S.BackButton>
-      </Link>
-      <S.HeaderTitle>카테고리</S.HeaderTitle>
-      <S.EmptyTag></S.EmptyTag>
-    </S.Header>
+    <>
+      <S.Header>
+        <Link to="/">
+          <S.BackButton>
+            <Icon name={ICON_NAME.CHEVRON_LEFT} />
+            <span>뒤로</span>
+          </S.BackButton>
+        </Link>
+        <S.HeaderTitle>카테고리</S.HeaderTitle>
+        <S.EmptyTag></S.EmptyTag>
+      </S.Header>
+
+      {responseState === RESPONSE_STATE.LOADING && <div>loading</div>}
+      {responseState === RESPONSE_STATE.ERROR && <div>error</div>}
+      {responseState === RESPONSE_STATE.SUCCESS &&
+        data?.categories.map((item) => <div key={item.id}>{item.name}</div>)}
+    </>
   );
 };
 

--- a/fe/src/pages/Category/style.ts
+++ b/fe/src/pages/Category/style.ts
@@ -24,12 +24,38 @@ const BackButton = styled.button`
   align-items: center;
   gap: 10px;
 
+  width: 100px;
+
   font-size: ${({ theme }) => theme.fonts.body.regular.fontSize};
   font-weight: ${({ theme }) => theme.fonts.body.regular.fontWeight};
   line-height: ${({ theme }) => theme.fonts.body.regular.lineHeight};
   color: ${({ theme }) => theme.colors.neutral.text.strong};
 `;
 
-const EmptyTag = styled.div``;
+const EmptyTag = styled.div`
+  width: 100px;
+`;
 
-export { Header, BackButton, HeaderTitle, EmptyTag };
+const CategoryImg = styled.img`
+  width: 44px;
+  height: 44px;
+
+  border-radius: 8px;
+`;
+
+const CategoryItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 80px;
+  height: 68px;
+
+  font-size: ${({ theme }) => theme.fonts.fontnote.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.fontnote.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.fontnote.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.default};
+`;
+
+export { Header, BackButton, HeaderTitle, EmptyTag, CategoryImg, CategoryItem };

--- a/fe/src/pages/Category/style.ts
+++ b/fe/src/pages/Category/style.ts
@@ -37,10 +37,12 @@ const EmptyTag = styled.div`
 `;
 
 const CategoryImg = styled.img`
-  width: 44px;
-  height: 44px;
+  width: 70%;
+  height: 70%;
 
   border-radius: 8px;
+
+  object-fit: cover;
 `;
 
 const CategoryItem = styled.div`
@@ -50,12 +52,23 @@ const CategoryItem = styled.div`
   align-items: center;
 
   width: 80px;
-  height: 68px;
+  height: 80px;
 
   font-size: ${({ theme }) => theme.fonts.fontnote.fontSize};
   font-weight: ${({ theme }) => theme.fonts.fontnote.fontWeight};
   line-height: ${({ theme }) => theme.fonts.fontnote.lineHeight};
   color: ${({ theme }) => theme.colors.neutral.text.default};
+
+  cursor: pointer;
 `;
 
-export { Header, BackButton, HeaderTitle, EmptyTag, CategoryImg, CategoryItem };
+const CategoryList = styled.section`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  justify-items: center;
+  gap: 27px;
+
+  padding: 40px;
+`;
+
+export { Header, BackButton, HeaderTitle, EmptyTag, CategoryImg, CategoryItem, CategoryList };

--- a/fe/src/pages/CategoryDetail/index.tsx
+++ b/fe/src/pages/CategoryDetail/index.tsx
@@ -1,0 +1,30 @@
+import { Link, useSearchParams } from 'react-router-dom';
+
+import { ICON_NAME } from '@constants/index';
+
+import Icon from '@components/common/Icon';
+import ProductList from '@components/ProductList';
+import * as S from './style';
+
+const CategoryDetail = () => {
+  const [searchParams] = useSearchParams();
+  const idParams = searchParams.get('id');
+  const nameParams = searchParams.get('name');
+
+  return (
+    <>
+      <S.Header>
+        <Link to="/categories">
+          <S.BackButton>
+            <Icon name={ICON_NAME.CHEVRON_LEFT} />
+          </S.BackButton>
+        </Link>
+        <S.HeaderTitle>{nameParams}</S.HeaderTitle>
+        <S.EmptyTag></S.EmptyTag>
+      </S.Header>
+      <ProductList categoryId={Number(idParams)} />
+    </>
+  );
+};
+
+export default CategoryDetail;

--- a/fe/src/pages/CategoryDetail/index.tsx
+++ b/fe/src/pages/CategoryDetail/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 
 import { ICON_NAME } from '@constants/index';
@@ -10,6 +11,11 @@ const CategoryDetail = () => {
   const [searchParams] = useSearchParams();
   const idParams = searchParams.get('id');
   const nameParams = searchParams.get('name');
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const goToTopHandler = () => {
+    listRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
   return (
     <>
@@ -23,9 +29,13 @@ const CategoryDetail = () => {
         <S.EmptyTag></S.EmptyTag>
       </S.Header>
 
-      <S.ProductListLayout>
+      <S.ProductListLayout ref={listRef}>
         <ProductList categoryId={Number(idParams)} />
       </S.ProductListLayout>
+
+      <S.GoToTopButton onClick={goToTopHandler}>
+        <Icon name={ICON_NAME.ARROW_UP} />
+      </S.GoToTopButton>
     </>
   );
 };

--- a/fe/src/pages/CategoryDetail/index.tsx
+++ b/fe/src/pages/CategoryDetail/index.tsx
@@ -22,7 +22,10 @@ const CategoryDetail = () => {
         <S.HeaderTitle>{nameParams}</S.HeaderTitle>
         <S.EmptyTag></S.EmptyTag>
       </S.Header>
-      <ProductList categoryId={Number(idParams)} />
+
+      <S.ProductListLayout>
+        <ProductList categoryId={Number(idParams)} />
+      </S.ProductListLayout>
     </>
   );
 };

--- a/fe/src/pages/CategoryDetail/style.ts
+++ b/fe/src/pages/CategoryDetail/style.ts
@@ -36,4 +36,9 @@ const EmptyTag = styled.div`
   width: 100px;
 `;
 
-export { Header, BackButton, HeaderTitle, EmptyTag };
+const ProductListLayout = styled.div`
+  height: calc(100vh - 44px);
+  overflow-y: scroll;
+`;
+
+export { Header, BackButton, HeaderTitle, EmptyTag, ProductListLayout };

--- a/fe/src/pages/CategoryDetail/style.ts
+++ b/fe/src/pages/CategoryDetail/style.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 45px;
+
+  height: 44px;
+  padding: 0 9px;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
+`;
+
+const HeaderTitle = styled.span`
+  font-size: ${({ theme }) => theme.fonts.body.bold.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.body.bold.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.bold.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.strong};
+`;
+
+const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  width: 100px;
+
+  font-size: ${({ theme }) => theme.fonts.body.regular.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.body.regular.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.regular.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.strong};
+`;
+
+const EmptyTag = styled.div`
+  width: 100px;
+`;
+
+export { Header, BackButton, HeaderTitle, EmptyTag };

--- a/fe/src/pages/CategoryDetail/style.ts
+++ b/fe/src/pages/CategoryDetail/style.ts
@@ -41,4 +41,21 @@ const ProductListLayout = styled.div`
   overflow-y: scroll;
 `;
 
-export { Header, BackButton, HeaderTitle, EmptyTag, ProductListLayout };
+const GoToTopButton = styled.button`
+  position: fixed;
+  bottom: 18px;
+  right: 18px;
+
+  width: 56px;
+  height: 56px;
+
+  background-color: ${({ theme }) => theme.colors.accent.background.primary};
+  border: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
+  border-radius: 56px;
+
+  & > svg {
+    fill: ${({ theme }) => theme.colors.accent.text.default};
+  }
+`;
+
+export { Header, BackButton, HeaderTitle, EmptyTag, ProductListLayout, GoToTopButton };


### PR DESCRIPTION
- #120 


## 📹 시연 영상

### 창의 크기에 따라 카테고리 버튼 layout 변경 (grid)
https://github.com/second-hand-team06/second-hand/assets/96980857/e9435ae8-1705-4f3a-9370-9b60edc2aba0

### 카테고리 버튼을 클릭하면 카테고리 상세 페이지로 이동
https://github.com/second-hand-team06/second-hand/assets/96980857/41e500f2-2006-4713-92e0-a2a4c5259cf8

### 스크롤 상단으로 이동
https://github.com/second-hand-team06/second-hand/assets/96980857/af82d032-74a6-4875-a422-3d47b2fa5936


## ☑️ 진행한 작업

### 카테고리 페이지
- [x] 카테고리 View
- [x] 각 카테고리를 누르면 카테고리가 적용된 페이지로 이동한다.

### 카테고리가 적용된 페이지
- [x] 카테고리가 적용된 동네 상품들을 화면에 보인다.

[<] 버튼
- [x] [<] 버튼을 누르면 카테고리 페이지로 이동한다.

[↑] 버튼
- [x] [↑] 버튼을 누르면 스크롤이 위로 이동한다.