### PR TITLE
[FE] 동네 Modal의 [내 동네 설정하기] 기능 구현

### DIFF
--- a/fe/src/components/common/Header/HomeHeader/index.tsx
+++ b/fe/src/components/common/Header/HomeHeader/index.tsx
@@ -1,18 +1,43 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
-import { ICON_NAME } from '@constants/index';
+import { ICON_NAME, REQUEST_METHOD } from '@constants/index';
+
+import useFetch from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
 import * as S from './style';
 
+interface Region {
+  id: number;
+  name: string;
+}
+
+interface RegionsData {
+  regions: Region[];
+}
+
 const HomeHeader = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { data } = useFetch<RegionsData>({
+    url: 'http://13.124.150.120:8080/users/regions',
+    method: REQUEST_METHOD.GET,
+  });
+  const isLoggedIn = localStorage.getItem('Token');
+
+  const firstDefaultRegion = '역삼 1동';
+  const defaultRegion = useMemo(() => {
+    if (!data) return;
+
+    const address = data.regions[0].name;
+
+    return address.split(' ').at(-1);
+  }, [data]);
 
   return (
     <S.HomeHeader>
       <S.NeighborhoodDropdown onClick={() => setIsModalOpen(!isModalOpen)}>
-        <span>역삼 1동</span>
+        <span>{isLoggedIn ? defaultRegion : firstDefaultRegion}</span>
         <Icon name={ICON_NAME.CHEVRON_DOWN} />
         {isModalOpen && (
           <S.Modal>

--- a/fe/src/components/common/Header/HomeHeader/index.tsx
+++ b/fe/src/components/common/Header/HomeHeader/index.tsx
@@ -17,6 +17,10 @@ interface RegionsData {
   regions: Region[];
 }
 
+const getRegion = (address: string) => {
+  return address.split(' ').at(-1);
+};
+
 const HomeHeader = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data } = useFetch<RegionsData>({
@@ -25,30 +29,45 @@ const HomeHeader = () => {
   });
   const isLoggedIn = localStorage.getItem('Token');
 
-  const firstDefaultRegion = '역삼 1동';
   const defaultRegion = useMemo(() => {
+    if (!isLoggedIn) return '역삼 1동';
     if (!data) return;
 
     const address = data.regions[0].name;
+    const region = getRegion(address);
 
-    return address.split(' ').at(-1);
+    return region;
   }, [data]);
+
+  const getDropDownMenuTemplate = () => {
+    if (!isLoggedIn) {
+      return (
+        <S.Menu defaultregion={defaultRegion} region={defaultRegion}>
+          {defaultRegion}
+        </S.Menu>
+      );
+    }
+
+    return (
+      <>
+        {data?.regions.map(({ id, name }) => (
+          <S.Menu key={id} defaultregion={defaultRegion} region={getRegion(name)}>
+            {getRegion(name)}
+          </S.Menu>
+        ))}
+        <Link to="/region-setting">
+          <S.Menu>내 동네 설정하기</S.Menu>
+        </Link>
+      </>
+    );
+  };
 
   return (
     <S.HomeHeader>
       <S.NeighborhoodDropdown onClick={() => setIsModalOpen(!isModalOpen)}>
-        <span>{isLoggedIn ? defaultRegion : firstDefaultRegion}</span>
+        <span>{defaultRegion}</span>
         <Icon name={ICON_NAME.CHEVRON_DOWN} />
-        {isModalOpen && (
-          <S.Modal>
-            <S.Menu defaultregion="역삼 1동" region="역삼 1동">
-              역삼 1동
-            </S.Menu>
-            <Link to="/region-setting">
-              <S.Menu>내 동네 설정하기</S.Menu>
-            </Link>
-          </S.Modal>
-        )}
+        {isModalOpen && <S.Modal>{getDropDownMenuTemplate()}</S.Modal>}
       </S.NeighborhoodDropdown>
       <Link to="/categories">
         <Icon name={ICON_NAME.HAMBURGER} />


### PR DESCRIPTION
- #100
## 시연 사진

1. 로그인 되지 않은 상태
<img width="417" alt="스크린샷 2023-06-22 오후 4 37 10" src="https://github.com/second-hand-team06/second-hand/assets/96980857/7e9a8c49-3821-4467-8cd3-373cc81d5277">

2. 로그인 된 상태
<img width="424" alt="스크린샷 2023-06-22 오후 4 38 14" src="https://github.com/second-hand-team06/second-hand/assets/96980857/72735ef5-5839-4139-908c-967abaa0e232">


## 진행한 작업

- [x] 로그인 이전이라면 동네 Modal에 [내 동네 설정하기]가 표시되지 않는다.
- [x] 로그인 이후라면 동네 Modal에 설정한 동네들과 [내 동네 설정하기]를 표시된다.
- [x] [내 동네 설정하기]를 누르면 동네 설정 페이지로 이동한다.