### PR TITLE
[FE] 카테고리 리스트 토글, 카테고리 선택 기능 구현 및 리팩토링

### DIFF
--- a/fe/src/components/CategoryList/index.tsx
+++ b/fe/src/components/CategoryList/index.tsx
@@ -1,0 +1,49 @@
+import { ICON_NAME, REQUEST_URL } from '@constants/index';
+
+import useFetch, { REQUEST_METHOD } from '@hooks/useFetch';
+
+import Icon from '@components/common/Icon';
+import * as S from './style';
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface CategoriesData {
+  categories: Category[];
+}
+
+const CategoryList = () => {
+  const { responseState, data } = useFetch<CategoriesData>({
+    url: REQUEST_URL.CATEGORY,
+    options: {
+      method: REQUEST_METHOD.GET,
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('Token')}`,
+      },
+    },
+  });
+
+  return (
+    <S.CategoryList>
+      <S.Header>
+        <S.BackButton>
+          <Icon name={ICON_NAME.CHEVRON_LEFT} />
+          <span>닫기</span>
+        </S.BackButton>
+        <S.HeaderTitle>카테고리</S.HeaderTitle>
+        <S.EmptyTag />
+      </S.Header>
+      {responseState === 'SUCCESS' && (
+        <S.CategoryListLayout>
+          {data?.categories.map(({ id, name }) => (
+            <S.CategoryItem key={id}>{name}</S.CategoryItem>
+          ))}
+        </S.CategoryListLayout>
+      )}
+    </S.CategoryList>
+  );
+};
+
+export default CategoryList;

--- a/fe/src/components/CategoryList/index.tsx
+++ b/fe/src/components/CategoryList/index.tsx
@@ -12,7 +12,7 @@ interface CategoriesData {
 
 interface CategoryListProps {
   category: Category;
-  onCategoryToggleClick: React.MouseEventHandler<HTMLButtonElement>;
+  onCategoryToggleClick: () => void;
   onCategorySelectClick: (category: Category) => void;
 }
 
@@ -43,7 +43,10 @@ const CategoryList = ({ category, onCategoryToggleClick, onCategorySelectClick }
             <S.CategoryItem
               key={id}
               className={category.id === id ? 'active' : ''}
-              onClick={() => onCategorySelectClick({ id, name })}
+              onClick={() => {
+                onCategorySelectClick({ id, name });
+                onCategoryToggleClick();
+              }}
             >
               {name}
             </S.CategoryItem>

--- a/fe/src/components/CategoryList/index.tsx
+++ b/fe/src/components/CategoryList/index.tsx
@@ -3,22 +3,20 @@ import { ICON_NAME, REQUEST_URL } from '@constants/index';
 import useFetch, { REQUEST_METHOD } from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
+import { Category } from '@pages/NewProduct';
 import * as S from './style';
-
-interface Category {
-  id: number;
-  name: string;
-}
 
 interface CategoriesData {
   categories: Category[];
 }
 
 interface CategoryListProps {
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  category: Category;
+  onCategoryToggleClick: React.MouseEventHandler<HTMLButtonElement>;
+  onCategorySelectClick: (category: Category) => void;
 }
 
-const CategoryList = ({ onClick }: CategoryListProps) => {
+const CategoryList = ({ category, onCategoryToggleClick, onCategorySelectClick }: CategoryListProps) => {
   const { responseState, data } = useFetch<CategoriesData>({
     url: REQUEST_URL.CATEGORY,
     options: {
@@ -32,7 +30,7 @@ const CategoryList = ({ onClick }: CategoryListProps) => {
   return (
     <S.CategoryList>
       <S.Header>
-        <S.CloseButton onClick={onClick}>
+        <S.CloseButton onClick={onCategoryToggleClick}>
           <Icon name={ICON_NAME.CHEVRON_LEFT} />
           <span>닫기</span>
         </S.CloseButton>
@@ -42,7 +40,13 @@ const CategoryList = ({ onClick }: CategoryListProps) => {
       {responseState === 'SUCCESS' && (
         <S.CategoryListLayout>
           {data?.categories.map(({ id, name }) => (
-            <S.CategoryItem key={id}>{name}</S.CategoryItem>
+            <S.CategoryItem
+              key={id}
+              className={category.id === id ? 'active' : ''}
+              onClick={() => onCategorySelectClick({ id, name })}
+            >
+              {name}
+            </S.CategoryItem>
           ))}
         </S.CategoryListLayout>
       )}

--- a/fe/src/components/CategoryList/index.tsx
+++ b/fe/src/components/CategoryList/index.tsx
@@ -14,7 +14,11 @@ interface CategoriesData {
   categories: Category[];
 }
 
-const CategoryList = () => {
+interface CategoryListProps {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const CategoryList = ({ onClick }: CategoryListProps) => {
   const { responseState, data } = useFetch<CategoriesData>({
     url: REQUEST_URL.CATEGORY,
     options: {
@@ -28,10 +32,10 @@ const CategoryList = () => {
   return (
     <S.CategoryList>
       <S.Header>
-        <S.BackButton>
+        <S.CloseButton onClick={onClick}>
           <Icon name={ICON_NAME.CHEVRON_LEFT} />
           <span>닫기</span>
-        </S.BackButton>
+        </S.CloseButton>
         <S.HeaderTitle>카테고리</S.HeaderTitle>
         <S.EmptyTag />
       </S.Header>

--- a/fe/src/components/CategoryList/style.ts
+++ b/fe/src/components/CategoryList/style.ts
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+const CategoryList = styled.div`
+  position: absolute;
+  top: 0;
+
+  width: 100%;
+  height: 100%;
+
+  background-color: ${({ theme }) => theme.colors.neutral.background.default};
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  height: 44px;
+  padding: 16px;
+
+  background-color: ${({ theme }) => theme.colors.neutral.background.blur};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
+`;
+
+const HeaderTitle = styled.span`
+  font-size: ${({ theme }) => theme.fonts.body.bold.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.body.bold.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.bold.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.strong};
+`;
+
+const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  width: 100px;
+
+  font-size: ${({ theme }) => theme.fonts.body.regular.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.body.regular.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.regular.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.strong};
+`;
+
+const EmptyTag = styled.div`
+  width: 100px;
+`;
+
+const CategoryListLayout = styled.ul`
+  margin: 0 16px;
+`;
+
+const CategoryItem = styled.li`
+  padding: 16px 0px;
+
+  font-size: ${({ theme }) => theme.fonts.subhead.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.subhead.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.subhead.lineHeight};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
+`;
+
+export { CategoryList, Header, HeaderTitle, BackButton, EmptyTag, CategoryListLayout, CategoryItem };

--- a/fe/src/components/CategoryList/style.ts
+++ b/fe/src/components/CategoryList/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { PALETTE } from '@styles/color';
 
 const CategoryList = styled.div`
   position: absolute;
@@ -58,6 +59,9 @@ const CategoryItem = styled.li`
   font-weight: ${({ theme }) => theme.fonts.subhead.fontWeight};
   line-height: ${({ theme }) => theme.fonts.subhead.lineHeight};
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
+
+  &.active {
+    color: ${PALETTE.ORANGE};
 `;
 
 export { CategoryList, Header, HeaderTitle, CloseButton, EmptyTag, CategoryListLayout, CategoryItem };

--- a/fe/src/components/CategoryList/style.ts
+++ b/fe/src/components/CategoryList/style.ts
@@ -30,7 +30,7 @@ const HeaderTitle = styled.span`
   color: ${({ theme }) => theme.colors.neutral.text.strong};
 `;
 
-const BackButton = styled.button`
+const CloseButton = styled.button`
   display: flex;
   align-items: center;
   gap: 10px;
@@ -60,4 +60,4 @@ const CategoryItem = styled.li`
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
 `;
 
-export { CategoryList, Header, HeaderTitle, BackButton, EmptyTag, CategoryListLayout, CategoryItem };
+export { CategoryList, Header, HeaderTitle, CloseButton, EmptyTag, CategoryListLayout, CategoryItem };

--- a/fe/src/components/TitleInput/index.tsx
+++ b/fe/src/components/TitleInput/index.tsx
@@ -5,27 +5,20 @@ import { ICON_NAME, REQUEST_URL } from '@constants/index';
 import useFetch, { REQUEST_METHOD } from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
-import CategoryList from '@components/CategoryList';
-import ModalPortal from '@components/ModalPortal';
+
 import * as S from './style';
-
-
-interface TitleInputProps {
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  // onClick: (e: React.MouseEvent) => void;
-}
 
 interface CategoriesData {
   categories: { id: number; name: string }[];
 }
 
-const TitleInput = ({ onChange }: TitleInputProps) => {
-  const [selectCategory, setSelectCategory] = useState(0);
-  const [showModal, setShowModal] = useState(false);
+interface TitleInputProps {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
 
-  const modalHandler = () => {
-    setShowModal((prev) => !prev);
-  };
+const TitleInput = ({ onChange, onClick }: TitleInputProps) => {
+  const [selectCategory, setSelectCategory] = useState(0);
 
   const token = localStorage.getItem('Token');
   const options: RequestInit = {
@@ -44,11 +37,6 @@ const TitleInput = ({ onChange }: TitleInputProps) => {
 
   return (
     <>
-      {showModal && (
-        <ModalPortal>
-          <CategoryList />
-        </ModalPortal>
-      )}
       <S.TitleInputLayout>
         <S.TitleInput placeholder="글 제목" onChange={onChange}></S.TitleInput>
 
@@ -64,7 +52,7 @@ const TitleInput = ({ onChange }: TitleInputProps) => {
               </S.CategoryItem>
             ))}
           </S.CategoryList>
-          <S.CategoryListButton onClick={modalHandler}>
+          <S.CategoryListButton onClick={onClick}>
             <Icon name={ICON_NAME.CHEVRON_RIGHT} />
           </S.CategoryListButton>
         </S.CategoryLayout>

--- a/fe/src/components/TitleInput/index.tsx
+++ b/fe/src/components/TitleInput/index.tsx
@@ -1,58 +1,57 @@
-import { useState } from 'react';
-
 import { ICON_NAME, REQUEST_URL } from '@constants/index';
 
 import useFetch, { REQUEST_METHOD } from '@hooks/useFetch';
 
 import Icon from '@components/common/Icon';
-
+import { Category } from '@pages/NewProduct';
 import * as S from './style';
 
 interface CategoriesData {
-  categories: { id: number; name: string }[];
+  categories: Category[];
 }
 
 interface TitleInputProps {
+  category: Category;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onCategoryToggleClick: React.MouseEventHandler<HTMLButtonElement>;
+  onCategorySelectClick: (category: Category) => void;
 }
 
-const TitleInput = ({ onChange, onClick }: TitleInputProps) => {
-  const [selectCategory, setSelectCategory] = useState(0);
-
+const TitleInput = ({
+  category,
+  onChange,
+  onCategoryToggleClick,
+  onCategorySelectClick,
+}: TitleInputProps) => {
   const token = localStorage.getItem('Token');
   const options: RequestInit = {
     method: REQUEST_METHOD.GET.toString(),
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   };
 
-  const { data } = useFetch<CategoriesData>({
-    url: `${REQUEST_URL.CATEGORY_RECOMMENDS}?title='`,
+  const { responseState, data } = useFetch<CategoriesData>({
+    url: `${REQUEST_URL.CATEGORY_RECOMMENDS}?title=''`, //todo: title부분에 값 넣어줘야함
     options,
   });
-
-  const selectCategoryHandler = (e: React.MouseEvent<HTMLDivElement>, idx: number) => {
-    setSelectCategory(idx);
-  };
 
   return (
     <>
       <S.TitleInputLayout>
         <S.TitleInput placeholder="글 제목" onChange={onChange}></S.TitleInput>
-
         <S.CategoryLayout>
           <S.CategoryList>
-            {data?.categories.map(({ id, name }, idx) => (
-              <S.CategoryItem
-                key={id}
-                className={selectCategory === idx ? 'active' : ''}
-                onClick={(e) => selectCategoryHandler(e, idx)}
-              >
-                {name}
-              </S.CategoryItem>
-            ))}
+            {responseState === 'SUCCESS' &&
+              data?.categories.map(({ id, name }) => (
+                <S.CategoryItem
+                  key={id}
+                  className={category.id === id ? 'active' : ''}
+                  onClick={() => onCategorySelectClick({ id, name })}
+                >
+                  {name}
+                </S.CategoryItem>
+              ))}
           </S.CategoryList>
-          <S.CategoryListButton onClick={onClick}>
+          <S.CategoryListButton onClick={onCategoryToggleClick}>
             <Icon name={ICON_NAME.CHEVRON_RIGHT} />
           </S.CategoryListButton>
         </S.CategoryLayout>

--- a/fe/src/components/TitleInput/index.tsx
+++ b/fe/src/components/TitleInput/index.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react';
+
 import { ICON_NAME, REQUEST_URL } from '@constants/index';
+
 import useFetch, { REQUEST_METHOD } from '@hooks/useFetch';
+
 import Icon from '@components/common/Icon';
+import CategoryList from '@components/CategoryList';
+import ModalPortal from '@components/ModalPortal';
 import * as S from './style';
+
 
 interface TitleInputProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  // onClick: (e: React.MouseEvent) => void;
 }
 
 interface CategoriesData {
@@ -14,6 +21,12 @@ interface CategoriesData {
 
 const TitleInput = ({ onChange }: TitleInputProps) => {
   const [selectCategory, setSelectCategory] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+
+  const modalHandler = () => {
+    setShowModal((prev) => !prev);
+  };
+
   const token = localStorage.getItem('Token');
   const options: RequestInit = {
     method: REQUEST_METHOD.GET.toString(),
@@ -30,24 +43,33 @@ const TitleInput = ({ onChange }: TitleInputProps) => {
   };
 
   return (
-    <S.TitleInputLayout>
-      <S.TitleInput placeholder="글 제목" onChange={onChange}></S.TitleInput>
+    <>
+      {showModal && (
+        <ModalPortal>
+          <CategoryList />
+        </ModalPortal>
+      )}
+      <S.TitleInputLayout>
+        <S.TitleInput placeholder="글 제목" onChange={onChange}></S.TitleInput>
 
-      <S.CategoryLayout>
-        <S.CategoryList>
-          {data?.categories.map(({ id, name }, idx) => (
-            <S.CategoryItem
-              key={id}
-              className={selectCategory === idx ? 'active' : ''}
-              onClick={(e) => selectCategoryHandler(e, idx)}
-            >
-              {name}
-            </S.CategoryItem>
-          ))}
-        </S.CategoryList>
-        <Icon name={ICON_NAME.CHEVRON_RIGHT} />
-      </S.CategoryLayout>
-    </S.TitleInputLayout>
+        <S.CategoryLayout>
+          <S.CategoryList>
+            {data?.categories.map(({ id, name }, idx) => (
+              <S.CategoryItem
+                key={id}
+                className={selectCategory === idx ? 'active' : ''}
+                onClick={(e) => selectCategoryHandler(e, idx)}
+              >
+                {name}
+              </S.CategoryItem>
+            ))}
+          </S.CategoryList>
+          <S.CategoryListButton onClick={modalHandler}>
+            <Icon name={ICON_NAME.CHEVRON_RIGHT} />
+          </S.CategoryListButton>
+        </S.CategoryLayout>
+      </S.TitleInputLayout>
+    </>
   );
 };
 

--- a/fe/src/components/TitleInput/index.tsx
+++ b/fe/src/components/TitleInput/index.tsx
@@ -40,6 +40,9 @@ const TitleInput = ({
         <S.TitleInput placeholder="글 제목" onChange={onChange}></S.TitleInput>
         <S.CategoryLayout>
           <S.CategoryList>
+            {!data?.categories.some((item) => item.id === category.id) && category.id !== 0 && (
+              <S.CategoryItem className="active">{category.name}</S.CategoryItem>
+            )}
             {responseState === 'SUCCESS' &&
               data?.categories.map(({ id, name }) => (
                 <S.CategoryItem

--- a/fe/src/components/TitleInput/index.tsx
+++ b/fe/src/components/TitleInput/index.tsx
@@ -13,7 +13,7 @@ interface CategoriesData {
 interface TitleInputProps {
   category: Category;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onCategoryToggleClick: React.MouseEventHandler<HTMLButtonElement>;
+  onCategoryToggleClick: () => void;
   onCategorySelectClick: (category: Category) => void;
 }
 

--- a/fe/src/components/TitleInput/style.ts
+++ b/fe/src/components/TitleInput/style.ts
@@ -56,4 +56,7 @@ const CategoryLayout = styled.div`
   width: 100%;
 `;
 
-export { TitleInputLayout, TitleInput, CategoryList, CategoryItem, CategoryLayout };
+const CategoryListButton = styled.button`
+`;
+
+export { TitleInputLayout, TitleInput, CategoryList, CategoryItem, CategoryLayout, CategoryListButton };

--- a/fe/src/pages/NewProduct/index.tsx
+++ b/fe/src/pages/NewProduct/index.tsx
@@ -94,12 +94,12 @@ const NewProduct = () => {
   };
 
   return (
-    <S.NewProduct>
+    <>
       <S.Header>
         <Link to={PATH.HOME}>
           <S.CloseButton>닫기</S.CloseButton>
         </Link>
-        <S.HeaderTitle>내 물건 팔기</S.HeaderTitle>
+        <span>내 물건 팔기</span>
         <S.CompleteButton onClick={submitHandler}>완료</S.CompleteButton>
       </S.Header>
       <S.LayoutContent>
@@ -120,7 +120,7 @@ const NewProduct = () => {
           <Icon name={ICON_NAME.KEYBOARD} fill="black" />
         </S.Keyboard>
       </S.TabBar>
-    </S.NewProduct>
+    </>
   );
 };
 

--- a/fe/src/pages/NewProduct/index.tsx
+++ b/fe/src/pages/NewProduct/index.tsx
@@ -9,6 +9,8 @@ import useFetch, { REQUEST_METHOD } from '@hooks/useFetch';
 import Icon from '@components/common/Icon';
 import ImageInput from '@components/ImageInput';
 import TitleInput from '@components/TitleInput';
+import CategoryList from '@components/CategoryList';
+import ModalPortal from '@components/ModalPortal';
 import * as S from './style';
 
 interface UseFetchProps {
@@ -16,6 +18,13 @@ interface UseFetchProps {
 }
 
 const NewProduct = () => {
+  //모달 처리
+  const [isOpenCategory, setIsOpenCategory] = useState(false);
+
+  const categoryToggleHandler = () => {
+    setIsOpenCategory((prev) => !prev);
+  };
+
   const navigate = useNavigate();
 
   const [title, setTitle] = useState('');
@@ -95,6 +104,11 @@ const NewProduct = () => {
 
   return (
     <>
+      {isOpenCategory && (
+        <ModalPortal>
+          <CategoryList onClick={categoryToggleHandler} />
+        </ModalPortal>
+      )}
       <S.Header>
         <Link to={PATH.HOME}>
           <S.CloseButton>닫기</S.CloseButton>
@@ -104,7 +118,7 @@ const NewProduct = () => {
       </S.Header>
       <S.LayoutContent>
         <ImageInput onChange={imageUploadHandler} onDelete={deleteImageHandler} images={images} />
-        <TitleInput onChange={titleChangeHandler} />
+        <TitleInput onChange={titleChangeHandler} onClick={categoryToggleHandler} />
         <S.TextInput onChange={priceChangeHandler} placeholder="₩ 가격 (선택사항)" />
         <S.TextArea
           onChange={contentChangeHandler}

--- a/fe/src/pages/NewProduct/index.tsx
+++ b/fe/src/pages/NewProduct/index.tsx
@@ -13,16 +13,31 @@ import CategoryList from '@components/CategoryList';
 import ModalPortal from '@components/ModalPortal';
 import * as S from './style';
 
+export interface Category {
+  id: number;
+  name: string;
+}
+
 interface UseFetchProps {
   id: number;
 }
 
 const NewProduct = () => {
-  //모달 처리
   const [isOpenCategory, setIsOpenCategory] = useState(false);
+  const [category, setCategory] = useState({
+    id: 0,
+    name: '',
+  });
 
-  const categoryToggleHandler = () => {
+  const categoryToggleClickHandler = () => {
     setIsOpenCategory((prev) => !prev);
+  };
+
+  const categorySelectClickHandler = ({ id, name }: Category) => {
+    setCategory({
+      id,
+      name,
+    });
   };
 
   const navigate = useNavigate();
@@ -31,7 +46,6 @@ const NewProduct = () => {
   const [content, setContent] = useState('');
   // const [region, setRegion] = useState('');
   const [price, setPrice] = useState('');
-  // const [category, setCategory] = useState('');
   const [images, setImages] = useState<File[]>([]);
 
   const { responseState, fetchData, data } = useFetch<UseFetchProps>({
@@ -106,7 +120,11 @@ const NewProduct = () => {
     <>
       {isOpenCategory && (
         <ModalPortal>
-          <CategoryList onClick={categoryToggleHandler} />
+          <CategoryList
+            category={category}
+            onCategoryToggleClick={categoryToggleClickHandler}
+            onCategorySelectClick={categorySelectClickHandler}
+          />
         </ModalPortal>
       )}
       <S.Header>
@@ -118,7 +136,12 @@ const NewProduct = () => {
       </S.Header>
       <S.LayoutContent>
         <ImageInput onChange={imageUploadHandler} onDelete={deleteImageHandler} images={images} />
-        <TitleInput onChange={titleChangeHandler} onClick={categoryToggleHandler} />
+        <TitleInput
+          category={category}
+          onChange={titleChangeHandler}
+          onCategoryToggleClick={categoryToggleClickHandler}
+          onCategorySelectClick={categorySelectClickHandler}
+        />
         <S.TextInput onChange={priceChangeHandler} placeholder="₩ 가격 (선택사항)" />
         <S.TextArea
           onChange={contentChangeHandler}

--- a/fe/src/pages/NewProduct/index.tsx
+++ b/fe/src/pages/NewProduct/index.tsx
@@ -62,7 +62,7 @@ const NewProduct = () => {
 
     formData.append('title', title);
     formData.append('regionId', `${1}`);
-    formData.append('categoryId', `${1}`);
+    formData.append('categoryId', category.id.toString());
     formData.append('price', price);
     formData.append('badgeId', `${1}`);
     formData.append('content', content);
@@ -137,6 +137,7 @@ const NewProduct = () => {
       <S.LayoutContent>
         <ImageInput onChange={imageUploadHandler} onDelete={deleteImageHandler} images={images} />
         <TitleInput
+          title={title}
           category={category}
           onChange={titleChangeHandler}
           onCategoryToggleClick={categoryToggleClickHandler}

--- a/fe/src/pages/NewProduct/style.ts
+++ b/fe/src/pages/NewProduct/style.ts
@@ -1,7 +1,5 @@
 import styled from 'styled-components';
 
-const NewProduct = styled.div``;
-
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
@@ -13,9 +11,7 @@ const Header = styled.div`
 
   background-color: ${({ theme }) => theme.colors.neutral.background.blur};
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
-`;
 
-const HeaderTitle = styled.div`
   font-size: ${({ theme }) => theme.fonts.body.bold.fontSize};
   font-weight: ${({ theme }) => theme.fonts.body.bold.fontWeight};
   line-height: ${({ theme }) => theme.fonts.body.bold.lineHeight};
@@ -34,12 +30,13 @@ const CompleteButton = styled.button`
   line-height: ${({ theme }) => theme.fonts.body.regular.lineHeight};
   color: ${({ theme }) => theme.colors.neutral.text.default};
 `;
+// todo: 완료 버튼 입력이 다 됐을 경우에만 스타일 처리
 
 const TabBar = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  position: fixed;
+  position: absolute;
   bottom: 0;
 
   width: 100%;
@@ -82,9 +79,7 @@ const TextArea = styled.textarea`
 const Keyboard = styled.div``;
 
 export {
-  NewProduct,
   Header,
-  HeaderTitle,
   CloseButton,
   CompleteButton,
   TabBar,


### PR DESCRIPTION
- #213 
## 작업상황
<b>카테고리 리스트 토글</b>
- [>] 버튼을 누르면 카테고리 리스트가 보여진다.
- 카테고리 리스트에서 [닫기] 버튼을 누르면 카테고리가 닫힌다.

<b>카테고리 선택</b>
- 상품등록에서 선택
  - 카테고리 리스트에 들어가면 선택된 카테고리 색상 반영 
 - 카테고리리스트에서 선택
   - 상품 등록으로 돌아왔을 때 선택된 카테고리 추가 
   - 선택된 카테고리 POST 반영

<b>리팩토링</b>
- 카테고리 관련 타입 수정
- 카테고리 관련 handler 네이밍 수정
- state랑 handler newProduct에서 관리하고 props로 넘겨줌

https://github.com/second-hand-team06/second-hand/assets/115215178/4c681427-2a10-4d0d-90db-9fb01abcf5d8

![image](https://github.com/second-hand-team06/second-hand/assets/115215178/6073ed6d-8fbb-4386-afd0-4119e1897b65)

## 공유사항
- eventHandler랑 props 네이밍이 긴 이유는 onClick으로 넘겨줘야할 부분이 한개가 아니라 토글핸들러, 카테고리 선택 핸들러 두개였기 때문에 각 핸들러에 대한 의미가 명확하면 좋을 것 같아서 categoryToggleClickHandler, categorySelectClickHandler로 네이밍 지었어요!
- [네이밍 참고 사이트](https://youngmin.hashnode.dev/react-1) : 이 글 반영해서 네이밍 했숨다!

## 이후 처리할 것
- title 값 카테고리 데이터 fetch해올때 쿼리로 넣어주기