### PR TITLE
[FE] 채팅관련 UI 컴포넌트 생성

### DIFF
--- a/fe/src/components/ChatRoomItem/ChatRoomItem.stories.ts
+++ b/fe/src/components/ChatRoomItem/ChatRoomItem.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ChatRoomItem from '.';
+
+const chatRoomItemMeta: Meta<typeof ChatRoomItem> = {
+  title: 'ChatRoomItem',
+  component: ChatRoomItem,
+};
+
+export default chatRoomItemMeta;
+
+type ChatRoomItemStory = StoryObj<typeof ChatRoomItem>;
+
+export const Primary: ChatRoomItemStory = {
+  args: {
+    lastMessage: {
+      roomId: '12341324',
+      sender: {
+        name: 'Daon',
+        url: 'https://avatars.githubusercontent.com/u/115215178?v=4',
+      },
+      content: '아직 살 수 있나요?',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    productPhotoUrl: 'https://codesquad-s3.s3.ap-northeast-2.amazonaws.com/img/second-hand.pngebd33b68-f',
+    unreadCount: 1,
+  },
+};

--- a/fe/src/components/ChatRoomItem/index.tsx
+++ b/fe/src/components/ChatRoomItem/index.tsx
@@ -1,0 +1,37 @@
+import { getTimeStamp } from '@utils/index';
+import * as S from './style';
+
+type LastMessage = {
+  roomId: string;
+  sender: { name: string; url: string };
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+interface ChatRoomItemProps {
+  lastMessage: LastMessage;
+  productPhotoUrl: string;
+  unreadCount: number;
+}
+
+const ChatRoomItem = ({ lastMessage, productPhotoUrl, unreadCount }: ChatRoomItemProps) => {
+  return (
+    <S.ChatRoomItem>
+      <S.SenderImg src={lastMessage.sender.url} alt="sender image" />
+      <div>
+        <S.NameAndTime>
+          <S.SenderName>{lastMessage.sender.name}</S.SenderName>
+          <S.SendedTime>{getTimeStamp(lastMessage.createdAt)}</S.SendedTime>
+        </S.NameAndTime>
+        <S.LastMessageContent>{lastMessage.content}</S.LastMessageContent>
+      </div>
+      <S.CountAndPhoto>
+        <S.UnreadCount>{unreadCount}</S.UnreadCount>
+        <S.ProductPhotoUrl src={productPhotoUrl} alt="product-thumbnail" />
+      </S.CountAndPhoto>
+    </S.ChatRoomItem>
+  );
+};
+
+export default ChatRoomItem;

--- a/fe/src/components/ChatRoomItem/style.ts
+++ b/fe/src/components/ChatRoomItem/style.ts
@@ -1,0 +1,85 @@
+import styled from 'styled-components';
+
+const SenderImg = styled.img`
+  width: 48px;
+  height: 48px;
+
+  border-radius: 50%;
+`;
+
+const SenderName = styled.span`
+  font-size: ${({ theme }) => theme.fonts.subhead.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.subhead.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.subhead.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.strong};
+`;
+
+const SendedTime = styled.span`
+  font-size: ${({ theme }) => theme.fonts.footnote.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.footnote.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.footnote.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.weak};
+`;
+
+const LastMessageContent = styled.span`
+  font-size: ${({ theme }) => theme.fonts.footnote.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.footnote.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.footnote.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.text.default};
+`;
+
+const UnreadCount = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 20px;
+  height: 20px;
+
+  background-color: ${({ theme }) => theme.colors.accent.background.primary};
+  border-radius: 50%;
+
+  font-size: ${({ theme }) => theme.fonts.caption2.fontSize};
+  font-weight: ${({ theme }) => theme.fonts.caption2.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.caption2.lineHeight};
+  color: ${({ theme }) => theme.colors.neutral.background.default};
+`;
+
+const ProductPhotoUrl = styled.img`
+  width: 48px;
+  height: 48px;
+
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.neutral.border.default};
+`;
+
+const NameAndTime = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 3px;
+`;
+
+const CountAndPhoto = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const ChatRoomItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  padding: 16px;
+`;
+
+export {
+  SenderImg,
+  SenderName,
+  SendedTime,
+  LastMessageContent,
+  UnreadCount,
+  ProductPhotoUrl,
+  NameAndTime,
+  CountAndPhoto,
+  ChatRoomItem,
+};

--- a/fe/src/components/common/Mesage/Message.stories.ts
+++ b/fe/src/components/common/Mesage/Message.stories.ts
@@ -5,6 +5,9 @@ import Message from '.';
 const messageMeta: Meta<typeof Message> = {
   title: 'common/Message',
   component: Message,
+  argTypes: {
+    type: { options: ['you', 'me'], control: { type: 'radio' } },
+  },
 };
 
 export default messageMeta;

--- a/fe/src/components/common/Mesage/Message.stories.ts
+++ b/fe/src/components/common/Mesage/Message.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Message from '.';
+
+const messageMeta: Meta<typeof Message> = {
+  title: 'common/Message',
+  component: Message,
+};
+
+export default messageMeta;
+
+type MessageStory = StoryObj<typeof Message>;
+
+export const PrimaryMessage: MessageStory = {
+  args: {
+    type: 'you',
+    content: '안녕하세요!\n\n궁금한 점이 있어서 챗 드려요',
+  },
+};

--- a/fe/src/components/common/Mesage/index.tsx
+++ b/fe/src/components/common/Mesage/index.tsx
@@ -1,0 +1,12 @@
+import * as S from './style';
+
+interface MessageProps {
+  type: 'me' | 'you';
+  content: string;
+}
+
+const Message = ({ type, content }: MessageProps) => {
+  return <S.Message type={type}>{content}</S.Message>;
+};
+
+export default Message;

--- a/fe/src/components/common/Mesage/style.ts
+++ b/fe/src/components/common/Mesage/style.ts
@@ -1,0 +1,24 @@
+import styled, { css } from 'styled-components';
+
+const MessageTypeStyles = {
+  you: css`
+    background-color: #d9d9d9;
+    color: ${({ theme }) => theme.colors.neutral.text.strong};
+  `,
+  me: css`
+    background-color: ${({ theme }) => theme.colors.accent.background.primary};
+    color: ${({ theme }) => theme.colors.accent.text.default};
+  `,
+};
+
+const Message = styled.div<{ type: 'me' | 'you' }>`
+  width: 267px;
+  padding: 6px 12px;
+
+  border-radius: 18px;
+
+  white-space: pre-wrap;
+  ${({ type }) => MessageTypeStyles[type]}
+`;
+
+export { Message };

--- a/fe/src/utils/index.tsx
+++ b/fe/src/utils/index.tsx
@@ -86,4 +86,4 @@ class CustomError extends Error {
   }
 }
 
-export { getTextWithTimeStamp, formatMoney, getRegion, getUserInfo, CustomError };
+export { getTimeStamp, getTextWithTimeStamp, formatMoney, getRegion, getUserInfo, CustomError };


### PR DESCRIPTION
- #229 

## ☑️ 진행한 작업

- Message 컴포넌트 생성
  - type이 "you"일 경우
    <img width="278" alt="스크린샷 2023-07-31 오후 10 31 17" src="https://github.com/second-hand-team06/second-hand/assets/96980857/3a2d6913-70be-40d6-9646-3358812979c6">
  - type이 "me"인 경우
    <img width="278" alt="스크린샷 2023-07-31 오후 10 32 39" src="https://github.com/second-hand-team06/second-hand/assets/96980857/015a6d97-58fe-4bed-bdc6-861edece604e"> 
  - storybook 작성
- ChatRoomItem 컴포넌트 생성
  - lastMessage.sender.name: 채팅 보낸 사람의 이름
  - lastMessage.sender.url: 채팅 보낸 사람의 이미지
  - lastMessage.content: 마지막 메시지 내용
  - 현재 시간과 마지막 메시지 보낸 시간 차이 (lastMessage.createdAt로 계산)
  - productPhotoUrl: 상품 대표 이미지
  - unreadCount: 읽지 않은 메시지 개수
     <img width="249" alt="스크린샷 2023-07-31 오후 10 30 54" src="https://github.com/second-hand-team06/second-hand/assets/96980857/794b5011-ff77-4b44-b1a5-19c7578e4978">
  - storybook 작성